### PR TITLE
style fix

### DIFF
--- a/src/components/sheets/local-components/modals/image-upload-modal/ImageUpload.scss
+++ b/src/components/sheets/local-components/modals/image-upload-modal/ImageUpload.scss
@@ -15,8 +15,7 @@
   padding: 2rem;
   border-radius: 8px;
   position: relative;
-  min-height: 400px;
-  max-height: 80vh;
+  height: 400px;
   max-width: 500px;
   width: 90%;
   border: none;
@@ -73,7 +72,9 @@
     p {
       margin: 0;
       color: #666;
-      word-break: break-word;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
   
     input {
@@ -109,6 +110,7 @@
     display: flex;
     align-items: center;
     gap: 1rem;
+    margin-right: 1rem;
     flex: 1;
     min-width: 0;
     .selected-file-name {
@@ -118,11 +120,12 @@
       flex-direction: column;
       flex: 1;
       min-width: 0;
-      
-      span {
-        word-break: break-word;
+      .filename-text {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        width: 100%;
       }
-      
       .cropped-indicator {
         border: 1px solid #A9080E;
         color: #A9080E;

--- a/src/components/sheets/local-components/modals/image-upload-modal/ImageUploadModal.jsx
+++ b/src/components/sheets/local-components/modals/image-upload-modal/ImageUploadModal.jsx
@@ -129,7 +129,7 @@ const ImageUploadModal = ({ onClose, onUpload, isCameFromProfile = false }) => {
             />
           </div>
           <div className="selected-file-name">
-            <span>{selectedFile.name}</span>
+            <span className="filename-text">{selectedFile.name}</span>
             {croppedFile && (
               <span className="cropped-indicator">Cropped</span>
             )}


### PR DESCRIPTION
fix https://github.com/OpenPecha/webuddhist-feedbacks/issues/1

<img width="1724" height="984" alt="Screenshot 2025-10-24 at 4 54 37 PM" src="https://github.com/user-attachments/assets/b0e51504-3bb4-4a00-96d5-526a7dee27a0" />

can go with truncated filename or show full? 
here, with full display of the name
